### PR TITLE
Fix unnecessary logging when calling sendFile

### DIFF
--- a/src/ServerResponse.ts
+++ b/src/ServerResponse.ts
@@ -106,11 +106,7 @@ export class ServerResponse extends EventEmitter /* implements http.ServerRespon
   sendFile(path: string, fn?: (err: Error) => void): void {
     this.type(path);
     fs.readFile(path, (err, contents) => {
-      if (err) {
-        return fn(err);
-      } else {
-        console.error(err);
-      }
+      if (err) return fn(err);
       this.send(contents);
     });
   }


### PR DESCRIPTION
The code basically says:
if (error) return log(error) else log(error)
which results in
![image](https://user-images.githubusercontent.com/67780699/143776692-9a07b267-a7a0-4eb2-8406-aea3e29b35b2.png)

This change should fix this confusing and unnecessary error logging
