### PR TITLE
Fix JSON body with multibyte strings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uwebsockets-express",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uwebsockets-express",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "http-status-codes": "^2.1.4",
@@ -20,7 +20,7 @@
         "@types/mocha": "^8.2.2",
         "@types/path-to-regexp": "^1.7.0",
         "@types/serve-index": "^1.9.0",
-        "axios": "^1.4.0",
+        "axios": "1.4.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -409,9 +409,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axios": "1.4.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
-    "express": "^4.17.1",
+    "express": "^4.18.1",
     "express-session": "^1.17.2",
     "mocha": "^9.0.1",
     "pug": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/mocha": "^8.2.2",
     "@types/path-to-regexp": "^1.7.0",
     "@types/serve-index": "^1.9.0",
-    "axios": "^1.4.0",
+    "axios": "1.4.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/src/IncomingMessage.ts
+++ b/src/IncomingMessage.ts
@@ -78,7 +78,7 @@ export class IncomingMessage extends EventEmitter implements http.IncomingMessag
   }
 
   get body () {
-    return this._bodydata || this._rawbody;
+    return this._bodydata || this._rawbody?.toString();
   }
 
   get headers (): http.IncomingHttpHeaders {
@@ -163,7 +163,7 @@ export class IncomingMessage extends EventEmitter implements http.IncomingMessag
       //
       const rejectionTimeout = setTimeout(() => {
         if (body) {
-          this._rawbody = body.toString();
+          this._rawbody = body;
           this.headers['content-length'] = String(body.length);
         }
         reject();
@@ -175,8 +175,8 @@ export class IncomingMessage extends EventEmitter implements http.IncomingMessag
 
         if (isLast) {
           clearTimeout(rejectionTimeout);
-          this._rawbody = body.toString();
-          resolve(this._rawbody !== "");
+          this._rawbody = body;
+          resolve(body.length > 0);
         }
       });
     })

--- a/test/compatibility_test.ts
+++ b/test/compatibility_test.ts
@@ -116,8 +116,8 @@ describe("uWS Express API Compatibility", () => {
       });
 
       const response = (await http.get(`${URL}/cookie`)).headers;
-      assert.strictEqual(1, response['set-cookie'].length);
-      assert.match(response["set-cookie"][0], /^\s?my-cookie/);
+      assert.strictEqual(1, response['set-cookie']!.length);
+      assert.match(response["set-cookie"]![0], /^\s?my-cookie/);
     })
 
     it("clearCookie()", async () => {
@@ -127,8 +127,8 @@ describe("uWS Express API Compatibility", () => {
       });
 
       const response = (await http.get(`${URL}/clearcookie`)).headers;
-      assert.strictEqual(1, response['set-cookie'].length);
-      assert.match(response["set-cookie"][0], /^\s?my-cookie=\;/);
+      assert.strictEqual(1, response['set-cookie']!.length);
+      assert.match(response["set-cookie"]![0], /^\s?my-cookie=\;/);
     })
 
     it("render()", async () => {
@@ -298,6 +298,7 @@ describe("uWS Express API Compatibility", () => {
         res.json({ existing, nonexisting, useragent });
       });
 
+      // be sure to ONLY use axios 1.4 in package.json for this test
       assert.deepStrictEqual({
         existing: "one",
         useragent: "axios/1.4.0",
@@ -440,12 +441,12 @@ describe("uWS Express API Compatibility", () => {
     it("should run at every request", async () => {
       app.use((req, res, next) => {
         res.set("header1", "one");
-        next();
+        next!();
       });
 
       app.use((req, res, next) => {
         res.set("header2", "two");
-        next();
+        next!();
       });
 
       app.get("/hey", (req, res) => res.end("done"));
@@ -459,17 +460,17 @@ describe("uWS Express API Compatibility", () => {
     it("should support middlewares at specific segments", async () => {
       app.use((req, res, next) => {
         res.set("catch-all", "all");
-        next();
+        next!();
       });
 
       app.use("/users/:id", (req, res, next) => {
         res.set("token", req.params['id']);
-        next();
+        next!();
       });
 
       app.use("/teams", (req, res, next) => {
         res.set("team", "team");
-        next();
+        next!();
       });
 
       app.get("/users/:id", (req, res) => res.json({ user: req.params.id }));
@@ -544,7 +545,7 @@ describe("uWS Express API Compatibility", () => {
 
       app.get("/one", (req, res, next) => {
         req['something'] = true;
-        next();
+        next!();
 
       }, (req, res) => {
         // @ts-ignore

--- a/test/compatibility_test.ts
+++ b/test/compatibility_test.ts
@@ -252,6 +252,14 @@ describe("uWS Express API Compatibility", () => {
       assert.strictEqual("small body", data);
     })
 
+    it("multibyte character body", async () => {
+      app.use(express.json());      
+      app.post("/multibyte_body", (req, res) => res.end(req.body?.str));
+
+      const { data } = (await http.post(`${URL}/multibyte_body`, {str: "multibyte 世界 body"}));
+      assert.strictEqual("multibyte 世界 body", data);
+    })    
+
     it("parse large request body", async () => {
       app.post("/large_body", (req, res) => res.end(req.body));
 


### PR DESCRIPTION
Added new test "multibyte character body" which would fail as it was.

_rawbody gets send to the data handler of the express `raw-data` handler, which validates the data.length is equal to the content-length header. Converting the data to a string changes the length from bytes to characters, so this failed every time with multibyte characters. 

Set _rawBody to retain the length in bytes (it remains a buffer), and it converted to string only when `body` getter is called.

`_bodydata` seems to only be used if something externally sets it via the `body` setter, so I did not want to change that.



(also fixed axios version to 1.4 so the userAgent test would pass).

