### PR TITLE
Move express from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "esbuild": "^0.23.0",
-    "express": "^4.18.1",
     "express-session": "^1.17.2",
     "fast-glob": "^3.3.2",
     "mocha": "^9.0.1",
@@ -55,6 +54,7 @@
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.24.0"
   },
   "dependencies": {
+    "express": "^4.18.1",
     "http-status-codes": "^2.1.4",
     "mime": "^2.5.2",
     "path-to-regexp": "^0.1.7"


### PR DESCRIPTION
`express` should be a dependency, not a devDependency, otherwise importing this library without express installed (example use case: using the library solely for converting uWS headers and requests into node's IncomingMessage and ServerResponse) will fail because Application.ts and IncomingMessage.ts both use `express`.

